### PR TITLE
Feature/18 manage multiple cars in one account

### DIFF
--- a/custom_components/smarthashtag/__init__.py
+++ b/custom_components/smarthashtag/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from pysmarthashtag.account import SmartAccount
 
-from .const import DOMAIN
+from .const import CONF_VEHICLE, DOMAIN
 from .coordinator import SmartHashtagDataUpdateCoordinator
 
 PLATFORMS: list[Platform] = [
@@ -33,6 +33,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             password=entry.data[CONF_PASSWORD],
         ),
     )
+    hass.data[DOMAIN][CONF_VEHICLE] = entry.data["vehicle"]
     # https://developers.home-assistant.io/docs/integration_fetching_data#coordinated-single-api-poll-for-data-for-all-entities
     await coordinator.async_config_entry_first_refresh()
 

--- a/custom_components/smarthashtag/config_flow.py
+++ b/custom_components/smarthashtag/config_flow.py
@@ -15,8 +15,8 @@ from .const import DOMAIN
 from .const import LOGGER
 
 
-class BlueprintFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
-    """Config flow for Blueprint."""
+class SmartHashtagFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+    """Config flow for Smart #1 / #3 integration."""
 
     VERSION = 1
 

--- a/custom_components/smarthashtag/config_flow.py
+++ b/custom_components/smarthashtag/config_flow.py
@@ -1,6 +1,6 @@
 """Adds config flow for Smart #1/#3 integration."""
 from __future__ import annotations
-from typing import Final, KeysView
+from typing import KeysView
 
 import voluptuous as vol
 from homeassistant import config_entries
@@ -12,11 +12,10 @@ from pysmarthashtag.models import (
     SmartAPIError,
 )
 
-from .const import DOMAIN
+from .const import DOMAIN, NAME
 from .const import LOGGER
-
-CONF_VEHICLE: Final = "vehicle"
-CONF_VEHICLES: Final = "vehicles"
+from .const import CONF_VEHICLE
+from .const import CONF_VEHICLES
 
 
 class SmartHashtagFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -77,7 +76,7 @@ class SmartHashtagFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if len(self.init_info[CONF_VEHICLES]) == 1 or user_input is not None:
             if user_input is None:
                 user_input = {CONF_VEHICLE: self.init_info[CONF_VEHICLES][0]}
-            name = user_input[CONF_VEHICLE].lower()
+            name = f"{NAME} {user_input[CONF_VEHICLE]}"
             await self.async_set_unique_id(name)
             return self.async_create_entry(
                 title=name,

--- a/custom_components/smarthashtag/const.py
+++ b/custom_components/smarthashtag/const.py
@@ -5,10 +5,10 @@ from logging import Logger
 LOGGER: Logger = getLogger(__package__)
 
 # Base component constants
-NAME = "Smart #1/#3 Integration"
+NAME = "Smart"
 DOMAIN = "smarthashtag"
 DOMAIN_DATA = f"{DOMAIN}_data"
-VERSION = "0.1.0"
+VERSION = "0.2.0"
 
 ATTRIBUTION = "Data provided by http://smart.com/"
 ISSUE_URL = "https://github.com/DasBasti/SmartHashtag/issues"

--- a/custom_components/smarthashtag/const.py
+++ b/custom_components/smarthashtag/const.py
@@ -1,6 +1,7 @@
 """Constants for Smart #1/#3 integration."""
 from logging import getLogger
 from logging import Logger
+from typing import Final
 
 LOGGER: Logger = getLogger(__package__)
 
@@ -39,3 +40,6 @@ If you have any issues with this you need to open an issue here:
 {ISSUE_URL}
 -------------------------------------------------------------------
 """
+
+CONF_VEHICLE: Final = "vehicle"
+CONF_VEHICLES: Final = "vehicles"

--- a/custom_components/smarthashtag/entity.py
+++ b/custom_components/smarthashtag/entity.py
@@ -15,6 +15,7 @@ class SmartHashtagEntity(CoordinatorEntity):
     """BlueprintEntity class."""
 
     _attr_attribution = ATTRIBUTION
+    _attr_has_entity_name = True
 
     def __init__(self, coordinator: SmartHashtagDataUpdateCoordinator) -> None:
         """Initialize."""

--- a/custom_components/smarthashtag/manifest.json
+++ b/custom_components/smarthashtag/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/DasBasti/SmartHashtag/issues",
   "requirements": ["pysmarthashtag==0.2.0"],
-  "version": "0.1.0"
+  "version": "0.2.0"
 }

--- a/custom_components/smarthashtag/manifest.json
+++ b/custom_components/smarthashtag/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/DasBasti/SmartHashtag/issues",
-  "requirements": ["pysmarthashtag==0.1.7"],
+  "requirements": ["pysmarthashtag==0.2.0"],
   "version": "0.1.0"
 }

--- a/custom_components/smarthashtag/manifest.json
+++ b/custom_components/smarthashtag/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/DasBasti/SmartHashtag/issues",
-  "requirements": ["pysmarthashtag==0.2.2"],
+  "requirements": ["pysmarthashtag==0.2.3"],
   "version": "0.2.0"
 }

--- a/custom_components/smarthashtag/manifest.json
+++ b/custom_components/smarthashtag/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/DasBasti/SmartHashtag/issues",
-  "requirements": ["pysmarthashtag==0.2.0"],
+  "requirements": ["pysmarthashtag==0.2.2"],
   "version": "0.2.0"
 }

--- a/custom_components/smarthashtag/manifest.json
+++ b/custom_components/smarthashtag/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "smarthashtag",
-  "name": "Smart Hashtag",
+  "name": "Smart",
   "codeowners": ["@DasBasti"],
   "config_flow": true,
   "documentation": "https://github.com/DasBasti/SmartHashtag",

--- a/custom_components/smarthashtag/sensor.py
+++ b/custom_components/smarthashtag/sensor.py
@@ -4,8 +4,12 @@ import dataclasses
 
 from datetime import timedelta
 
-from homeassistant.components.sensor import SensorEntity
-from homeassistant.components.sensor import SensorEntityDescription
+from homeassistant.components.sensor import (
+    SensorEntity,
+    SensorEntityDescription,
+    SensorDeviceClass,
+)
+
 from pysmarthashtag.models import ValueWithUnit
 
 from .const import DOMAIN
@@ -17,16 +21,21 @@ ENTITY_BATTERY_DESCRIPTIONS = (
         key="remaining_range",
         name="Remaining Range",
         icon="mdi:road-variant",
+        device_class=SensorDeviceClass.DISTANCE,
+        native_unit_of_measurement="km",
     ),
     SensorEntityDescription(
         key="remaining_range_at_full_charge",
         name="Remaining Range at full battery",
         icon="mdi:road-variant",
+        device_class=SensorDeviceClass.DISTANCE,
+        native_unit_of_measurement="km",
     ),
     SensorEntityDescription(
         key="remaining_battery_percent",
         name="Remaining battery charge",
         icon="mdi:percent",
+        device_class=SensorDeviceClass.BATTERY,
     ),
     # FIXME: Sort out type issue with None and Strings
     #    SensorEntityDescription(
@@ -48,26 +57,34 @@ ENTITY_BATTERY_DESCRIPTIONS = (
         key="charging_voltage",
         name="Charging voltage",
         icon="mdi:car-battery",
+        device_class=SensorDeviceClass.VOLTAGE,
     ),
     SensorEntityDescription(
         key="charging_current",
         name="Charging current",
         icon="mdi:car-battery",
+        device_class=SensorDeviceClass.CURRENT,
+        native_unit_of_measurement="A",
     ),
     SensorEntityDescription(
         key="charging_power",
         name="Charging power",
         icon="mdi:car-battery",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement="W",
     ),
     SensorEntityDescription(
         key="charging_time_remaining",
         name="Charging time remaining",
         icon="mdi:clock-outline",
+        device_class=SensorDeviceClass.DURATION,
+        native_unit_of_measurement="min",
     ),
     SensorEntityDescription(
         key="charging_target_soc",
         name="Target state of charge",
         icon="mdi:percent",
+        device_class=SensorDeviceClass.BATTERY,
     ),
 )
 
@@ -91,41 +108,57 @@ ENTITY_TIRE_DESCRIPTIONS = (
         key="temperature_0",
         name="Tire temperature driver front",
         icon="mdi:thermometer",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement="°C",
     ),
     SensorEntityDescription(
         key="temperature_1",
         name="Tire temperature driver rear",
         icon="mdi:thermometer",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement="°C",
     ),
     SensorEntityDescription(
         key="temperature_2",
         name="Tire temperature passender front",
         icon="mdi:thermometer",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement="°C",
     ),
     SensorEntityDescription(
         key="temperature_3",
         name="Tire temperature passenger rear",
         icon="mdi:thermometer",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement="°C",
     ),
     SensorEntityDescription(
         key="tire_pressure_0",
         name="Tire pressure front driver",
         icon="mdi:gauge",
+        device_class=SensorDeviceClass.PRESSURE,
+        native_unit_of_measurement="hPa",
     ),
     SensorEntityDescription(
         key="tire_pressure_1",
         name="Tire pressure rear driver",
         icon="mdi:gauge",
+        device_class=SensorDeviceClass.PRESSURE,
+        native_unit_of_measurement="hPa",
     ),
     SensorEntityDescription(
         key="tire_pressure_2",
         name="Tire pressure front passenger",
         icon="mdi:gauge",
+        device_class=SensorDeviceClass.PRESSURE,
+        native_unit_of_measurement="hPa",
     ),
     SensorEntityDescription(
         key="tire_pressure_3",
         name="Tire pressure rear passenger",
         icon="mdi:gauge",
+        device_class=SensorDeviceClass.PRESSURE,
+        native_unit_of_measurement="hPa",
     ),
 )
 
@@ -134,22 +167,28 @@ ENTITY_GENERAL_DESCRIPTIONS = (
         key="last_update",
         name="Last update",
         icon="mdi:update",
+        device_class=SensorDeviceClass.TIMESTAMP,
     ),
     SensorEntityDescription(
         key="odometer",
-        name="ODO",
+        name="Odometer",
         icon="mdi:counter",
+        device_class=SensorDeviceClass.DISTANCE,
+        native_unit_of_measurement="km",
     ),
     SensorEntityDescription(
         key="service_daysToService",
         name="Service due in",
         icon="mdi:calendar-check",
-        native_unit_of_measurement="days",
+        device_class=SensorDeviceClass.DURATION,
+        native_unit_of_measurement="d",
     ),
     SensorEntityDescription(
         key="service_distanceToService",
         name="Service due in",
         icon="mdi:map-marker-distance",
+        device_class=SensorDeviceClass.DISTANCE,
+        native_unit_of_measurement="km",
     ),
 )
 

--- a/custom_components/smarthashtag/sensor.py
+++ b/custom_components/smarthashtag/sensor.py
@@ -12,7 +12,7 @@ from homeassistant.components.sensor import (
 
 from pysmarthashtag.models import ValueWithUnit
 
-from .const import DOMAIN
+from .const import CONF_VEHICLE, DOMAIN
 from .coordinator import SmartHashtagDataUpdateCoordinator
 from .entity import SmartHashtagEntity
 
@@ -206,37 +206,37 @@ def vin_from_key(key: str) -> str:
 async def async_setup_entry(hass, entry, async_add_devices):
     """Set up the sensor platform."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
+    vehicle = hass.data[DOMAIN][CONF_VEHICLE]
 
-    for vehicle in coordinator.account.vehicles:
-        async_add_devices(
-            SmartHashtagBatteryRangeSensor(
-                coordinator=coordinator,
-                entity_description=dataclasses.replace(
-                    entity_description, key=f"{vehicle}_{entity_description.key}"
-                ),
-            )
-            for entity_description in ENTITY_BATTERY_DESCRIPTIONS
+    async_add_devices(
+        SmartHashtagBatteryRangeSensor(
+            coordinator=coordinator,
+            entity_description=dataclasses.replace(
+                entity_description, key=f"{vehicle}_{entity_description.key}"
+            ),
         )
+        for entity_description in ENTITY_BATTERY_DESCRIPTIONS
+    )
 
-        async_add_devices(
-            SmartHashtagTireSensor(
-                coordinator=coordinator,
-                entity_description=dataclasses.replace(
-                    entity_description, key=f"{vehicle}_{entity_description.key}"
-                ),
-            )
-            for entity_description in ENTITY_TIRE_DESCRIPTIONS
+    async_add_devices(
+        SmartHashtagTireSensor(
+            coordinator=coordinator,
+            entity_description=dataclasses.replace(
+                entity_description, key=f"{vehicle}_{entity_description.key}"
+            ),
         )
+        for entity_description in ENTITY_TIRE_DESCRIPTIONS
+    )
 
-        async_add_devices(
-            SmartHashtagUpdateSensor(
-                coordinator=coordinator,
-                entity_description=dataclasses.replace(
-                    entity_description, key=f"{vehicle}_{entity_description.key}"
-                ),
-            )
-            for entity_description in ENTITY_GENERAL_DESCRIPTIONS
+    async_add_devices(
+        SmartHashtagUpdateSensor(
+            coordinator=coordinator,
+            entity_description=dataclasses.replace(
+                entity_description, key=f"{vehicle}_{entity_description.key}"
+            ),
         )
+        for entity_description in ENTITY_GENERAL_DESCRIPTIONS
+    )
 
 
 class SmartHashtagBatteryRangeSensor(SmartHashtagEntity, SensorEntity):
@@ -269,8 +269,8 @@ class SmartHashtagBatteryRangeSensor(SmartHashtagEntity, SensorEntity):
                 self.coordinator.update_interval = timedelta(minutes=5)
 
         if "charging_power" in self.entity_description.key:
-            if data.value < 0.0:
-                return data.value * -1.0
+            if data.value == -0.0:
+                return 0.0
 
         if isinstance(data, ValueWithUnit):
             return data.value

--- a/custom_components/smarthashtag/sensor.py
+++ b/custom_components/smarthashtag/sensor.py
@@ -268,6 +268,10 @@ class SmartHashtagBatteryRangeSensor(SmartHashtagEntity, SensorEntity):
             else:
                 self.coordinator.update_interval = timedelta(minutes=5)
 
+        if "charging_power" in self.entity_description.key:
+            if data.value < 0.0:
+                return data.value * -1.0
+
         if isinstance(data, ValueWithUnit):
             return data.value
 
@@ -318,12 +322,18 @@ class SmartHashtagTireSensor(SmartHashtagEntity, SensorEntity):
         """Return the unit of measurement of the sensor."""
         key = "_".join(self.entity_description.key.split("_")[1:-1])
         tire_idx = int(self.entity_description.key.split("_")[-1])
-        return getattr(
+        data = getattr(
             self.coordinator.account.vehicles.get(
                 vin_from_key(self.entity_description.key)
             ).tires,
             key,
-        )[tire_idx].unit
+        )[tire_idx]
+
+        # FIXME: if pysmarthashtag is updated to return the unit as °C remove this
+        if data.unit == "C":
+            return "°C"
+
+        return data.unit
 
 
 class SmartHashtagUpdateSensor(SmartHashtagEntity, SensorEntity):

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
-  "name": "Smart #1/#3",
+  "name": "Smart #1/#3 Integration",
   "hacs": "1.6.0",
-  "homeassistant": "2023.10.0 ",
+  "homeassistant": "2024.1.0b0",
   "render_readme": true
 }


### PR DESCRIPTION
If there are multiple vehicles in one account, a selection is displayed during setup. The user selects the VIN of the vehicle to set up and only the sensors regarding to this vin are read

Also there are some changes to the defaults of the sensors and the sensor naming.