### PR TITLE
Deprecate python 3.11 version in Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.12"]
     name: Pre-commit
     steps:
       - name: Check out the repository


### PR DESCRIPTION
Homeassistant needs 3.12 minimum