### PR TITLE
Update Intervals are not correct

### DIFF
--- a/custom_components/smarthashtag/climate.py
+++ b/custom_components/smarthashtag/climate.py
@@ -121,7 +121,7 @@ class SmartConditioningMode(ClimateEntity):
         )
         self._last_mode = HVACMode.HEAT_COOL
         self.coordinator.update_interval = timedelta(seconds=FAST_INTERVAL)
-        await self.coordinator.async_refresh()
+        await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self) -> None:
         """Turn off the climate system."""
@@ -130,7 +130,7 @@ class SmartConditioningMode(ClimateEntity):
         )
         self._last_mode = HVACMode.OFF
         self.coordinator.update_interval = timedelta(seconds=FAST_INTERVAL)
-        await self.coordinator.async_refresh()
+        await self.coordinator.async_request_refresh()
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature for the vehicle."""

--- a/custom_components/smarthashtag/climate.py
+++ b/custom_components/smarthashtag/climate.py
@@ -68,7 +68,10 @@ class SmartConditioningMode(ClimateEntity):
         )
 
         # value is true, last setting is off -> keep on requesting
-        if current_mode == self._last_mode:
+        if (
+            current_mode == self._last_mode
+            and self.coordinator.update_interval.seconds == FAST_INTERVAL
+        ):
             self.coordinator.update_interval = timedelta(
                 seconds=self.coordinator.config_entry.options.get(
                     CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL

--- a/custom_components/smarthashtag/sensor.py
+++ b/custom_components/smarthashtag/sensor.py
@@ -23,7 +23,6 @@ from .const import (
     DEFAULT_DRIVING_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
-    FAST_INTERVAL,
 )
 from .coordinator import SmartHashtagDataUpdateCoordinator
 from .entity import SmartHashtagEntity
@@ -1027,22 +1026,21 @@ class SmartHashtagBatteryRangeSensor(SmartHashtagEntity, SensorEntity):
             remove_vin_from_key(self.entity_description.key),
         )
 
-        if (
-            "charging_current" in self.entity_description.key
-            and self.coordinator.update_interval.seconds != FAST_INTERVAL
-        ):
+        if "charging_current" in self.entity_description.key:
+            scan_interval = self.coordinator.config_entry.options.get(
+                CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+            )
+            charging_interval = self.coordinator.config_entry.options.get(
+                CONF_CHARGING_INTERVAL, DEFAULT_CHARGING_INTERVAL
+            )
             if data.value != 0:
-                self.coordinator.update_interval = timedelta(
-                    seconds=self.coordinator.config_entry.options.get(
-                        CONF_CHARGING_INTERVAL, DEFAULT_CHARGING_INTERVAL
+                if self.coordinator.update_interval.seconds == scan_interval:
+                    self.coordinator.update_interval = timedelta(
+                        seconds=charging_interval
                     )
-                )
             else:
-                self.coordinator.update_interval = timedelta(
-                    seconds=self.coordinator.config_entry.options.get(
-                        CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
-                    )
-                )
+                if self.coordinator.update_interval.seconds == charging_interval:
+                    self.coordinator.update_interval = timedelta(seconds=scan_interval)
             self.hass.async_create_task(self.coordinator.async_request_refresh())
 
         if "charging_power" in self.entity_description.key:
@@ -1149,23 +1147,22 @@ class SmartHashtagUpdateSensor(SmartHashtagEntity, SensorEntity):
                 remove_vin_from_key(self.entity_description.key),
             )
 
-        if (
-            key == "engine_state"
-            and self.coordinator.update_interval.seconds != FAST_INTERVAL
-        ):
+        scan_interval = self.coordinator.config_entry.options.get(
+            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+        )
+        driving_interval = self.coordinator.config_entry.options.get(
+            CONF_DRIVING_INTERVAL, DEFAULT_DRIVING_INTERVAL
+        )
+        if key == "engine_state":
             if data == "engine_running":
-                self.coordinator.update_interval = timedelta(
-                    seconds=self.coordinator.config_entry.options.get(
-                        CONF_DRIVING_INTERVAL, DEFAULT_DRIVING_INTERVAL
+                if self.coordinator.update_interval.seconds == scan_interval:
+                    self.coordinator.update_interval = timedelta(
+                        seconds=driving_interval
                     )
-                )
                 self.icon = "mdi:engine"
             else:
-                self.coordinator.update_interval = timedelta(
-                    seconds=self.coordinator.config_entry.options.get(
-                        CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
-                    )
-                )
+                if self.coordinator.update_interval.seconds == driving_interval:
+                    self.coordinator.update_interval = timedelta(seconds=scan_interval)
                 self.icon = "mdi:engine-off"
                 self.hass.async_create_task(self.coordinator.async_request_refresh())
 

--- a/custom_components/smarthashtag/sensor.py
+++ b/custom_components/smarthashtag/sensor.py
@@ -1038,10 +1038,12 @@ class SmartHashtagBatteryRangeSensor(SmartHashtagEntity, SensorEntity):
                     self.coordinator.update_interval = timedelta(
                         seconds=charging_interval
                     )
+                    self.hass.async_create_task(
+                        self.coordinator.async_request_refresh()
+                    )
             else:
                 if self.coordinator.update_interval.seconds == charging_interval:
                     self.coordinator.update_interval = timedelta(seconds=scan_interval)
-            self.hass.async_create_task(self.coordinator.async_request_refresh())
 
         if "charging_power" in self.entity_description.key:
             if data.value == -0.0:
@@ -1159,12 +1161,12 @@ class SmartHashtagUpdateSensor(SmartHashtagEntity, SensorEntity):
                     self.coordinator.update_interval = timedelta(
                         seconds=driving_interval
                     )
+                self.hass.async_create_task(self.coordinator.async_request_refresh())
                 self.icon = "mdi:engine"
             else:
                 if self.coordinator.update_interval.seconds == driving_interval:
                     self.coordinator.update_interval = timedelta(seconds=scan_interval)
                 self.icon = "mdi:engine-off"
-                self.hass.async_create_task(self.coordinator.async_request_refresh())
 
         if isinstance(data, ValueWithUnit):
             return data.value


### PR DESCRIPTION
The update intervals got overwritten every update. This fixes it in a way that a sensor modifies the update interval only if it is default and resets it only if the interval is equal to the one it would have set.