### PR TITLE
Fix persistence issue for preconditioning

### DIFF
--- a/custom_components/smarthashtag/select.py
+++ b/custom_components/smarthashtag/select.py
@@ -81,9 +81,12 @@ class SmartPreHeatedLocation(SelectEntity):
         self.entity_description = SELECT_DESCRIPTIONS[location]
 
         # reload the last selected level
-        self._vehicle.climate_control.set_heating_level(
-            self._location, self._get_level_for_location(self._location)
-        )
+        try:
+            self._vehicle.climate_control.set_heating_level(
+                self._location, self._get_level_for_location(self._location)
+            )
+        except Exception as e:
+            LOGGER.warning("Failed to set initial heating level: %s", str(e))
 
     def _get_level_for_location(self, location: HeatingLocation) -> int:
         """Get the heating level for the specified location."""

--- a/custom_components/smarthashtag/select.py
+++ b/custom_components/smarthashtag/select.py
@@ -81,9 +81,16 @@ class SmartPreHeatedLocation(SelectEntity):
         self.entity_description = SELECT_DESCRIPTIONS[location]
 
         # reload the last selected level
+        self._vehicle.climate_control.set_heating_level(
+            self._location, self._get_level_for_location(self._location)
+        )
+
+    def _get_level_for_location(self, location: HeatingLocation) -> int:
+        """Get the heating level for the specified location."""
         if "selects" in self.coordinator.config_entry.data:
-            level = self.coordinator.config_entry.data["selects"].get(self._location, 0)
-            self._vehicle.climate_control.set_heating_level(self._location, level)
+            level = self.coordinator.config_entry.data["selects"].get(location, 0)
+            return level
+        return 0
 
     def select_option(self, option: str, **kwargs):
         """Change the selected option."""
@@ -107,7 +114,8 @@ class SmartPreHeatedLocation(SelectEntity):
     @property
     def current_option(self):
         """Return current heated steering setting."""
-        current_value = self._vehicle.climate_control.heating_levels[self._location]
+        current_value = self._get_level_for_location(self._location)
+        self._vehicle.climate_control.set_heating_level(self._location, current_value)
         current_str = next(
             (
                 key

--- a/custom_components/smarthashtag/select.py
+++ b/custom_components/smarthashtag/select.py
@@ -1,5 +1,6 @@
 """Support for Smart selects."""
 
+from typing import Literal
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.core import HomeAssistant
 
@@ -88,7 +89,7 @@ class SmartPreHeatedLocation(SelectEntity):
         except Exception as e:
             LOGGER.warning("Failed to set initial heating level: %s", str(e))
 
-    def _get_level_for_location(self, location: HeatingLocation) -> int:
+    def _get_level_for_location(self, location: HeatingLocation) -> Literal[0, 1, 2, 3]:
         """Get the heating level for the specified location."""
         if "selects" in self.coordinator.config_entry.data:
             level = self.coordinator.config_entry.data["selects"].get(location, 0)


### PR DESCRIPTION
pysmarthashtag does not have persistence when updating the vehicle information, so preconditioning levels need to be set again for every update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced management of heating levels for specified locations.
	- Improved persistence of selected heating levels across sessions.
- **Bug Fixes**
	- Improved error handling during initialization of heating levels.
- **Refactor**
	- Centralized logic for retrieving heating levels to improve code clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->