### PR TITLE
Bugfix selects breaking device config_entry

### DIFF
--- a/custom_components/smarthashtag/coordinator.py
+++ b/custom_components/smarthashtag/coordinator.py
@@ -60,11 +60,12 @@ class SmartHashtagDataUpdateCoordinator(DataUpdateCoordinator):
 
     def reset_update_interval(self, key: str):
         """Reset interval for this key to default"""
-        self.set_update_interval(
-            key,
-            timedelta(
-                seconds=self.config_entry.options.get(
-                    CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
-                )
-            ),
-        )
+        if self.config_entry:
+            self.set_update_interval(
+                key,
+                timedelta(
+                    seconds=self.config_entry.options.get(
+                        CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+                    )
+                ),
+            )

--- a/custom_components/smarthashtag/coordinator.py
+++ b/custom_components/smarthashtag/coordinator.py
@@ -69,3 +69,5 @@ class SmartHashtagDataUpdateCoordinator(DataUpdateCoordinator):
                     )
                 ),
             )
+        else:
+            LOGGER.warning("Cannot reset update interval due to missing config_entry")

--- a/custom_components/smarthashtag/select.py
+++ b/custom_components/smarthashtag/select.py
@@ -97,6 +97,8 @@ class SmartPreHeatedLocation(SelectEntity):
         ):
             level = self.coordinator.config_entry.data["selects"].get(location, 0)
             return level
+        else:
+            LOGGER.debug("No heating level found for %s", location)
         return 0
 
     async def async_select_option(self, option: str, **kwargs):

--- a/custom_components/smarthashtag/select.py
+++ b/custom_components/smarthashtag/select.py
@@ -91,7 +91,10 @@ class SmartPreHeatedLocation(SelectEntity):
 
     def _get_level_for_location(self, location: HeatingLocation) -> Literal[0, 1, 2, 3]:
         """Get the heating level for the specified location."""
-        if "selects" in self.coordinator.config_entry.data:
+        if (
+            self.coordinator.config_entry
+            and "selects" in self.coordinator.config_entry.data
+        ):
             level = self.coordinator.config_entry.data["selects"].get(location, 0)
             return level
         return 0

--- a/custom_components/smarthashtag/select.py
+++ b/custom_components/smarthashtag/select.py
@@ -99,13 +99,8 @@ class SmartPreHeatedLocation(SelectEntity):
             return level
         return 0
 
-    def select_option(self, option: str, **kwargs):
+    async def async_select_option(self, option: str, **kwargs):
         """Change the selected option."""
-
-        async def _update_config_entry(self, new_data):
-            self.hass.config_entries.async_update_entry(
-                self.coordinator.config_entry, data=new_data
-            )
 
         level: int = HEATING_LEVEL_OPTIONS_MAP[option]
         self._vehicle.climate_control.set_heating_level(self._location, level)
@@ -115,7 +110,9 @@ class SmartPreHeatedLocation(SelectEntity):
         if "selects" not in new_data:
             new_data["selects"] = {}
         new_data["selects"][self._location] = level
-        self.hass.add_job(_update_config_entry, self, new_data)
+        self.hass.config_entries.async_update_entry(
+            self.coordinator.config_entry, data=new_data
+        )
         LOGGER.debug(f"Setting {self._location} to %s", level)
 
     @property


### PR DESCRIPTION
Config entry did have issues with keeping entry_id during update. Making use of the async function for select_option keeps the correct id

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for configuration entry access in the SmartHashtagDataUpdateCoordinator.
	- Enhanced error handling for location data retrieval in the SmartPreHeatedLocation class.

- **New Features**
	- Introduced asynchronous execution for the select option functionality in the SmartPreHeatedLocation class. 

- **Refactor**
	- Streamlined the configuration update process by simplifying the method structure in SmartPreHeatedLocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->