### PR TITLE
Bump version of pySmartHashtag from 0.6.2 to 0.6.3

### DIFF
--- a/custom_components/smarthashtag/const.py
+++ b/custom_components/smarthashtag/const.py
@@ -9,7 +9,7 @@ LOGGER: Logger = getLogger(__package__)
 NAME = "Smart"
 DOMAIN = "smarthashtag"
 DOMAIN_DATA = f"{DOMAIN}_data"
-VERSION = "0.6.1"
+VERSION = "0.6.2"
 
 ATTRIBUTION = "Data provided by http://smart.com/"
 ISSUE_URL = "https://github.com/DasBasti/SmartHashtag/issues"

--- a/custom_components/smarthashtag/manifest.json
+++ b/custom_components/smarthashtag/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/DasBasti/SmartHashtag/issues",
-  "requirements": ["pysmarthashtag==0.6.2"],
-  "version": "0.6.1"
+  "requirements": ["pysmarthashtag==0.6.3"],
+  "version": "0.6.2"
 }


### PR DESCRIPTION
Includes potential bugfix for preconditioning ending early

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated SmartHashtag integration version from 0.6.1 to 0.6.2
	- Updated dependency `pysmarthashtag` from version 0.6.2 to 0.6.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->