### PR TITLE
Update Home Assistant version to 2024.11.0 in hacs.json

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "Smart #1/#3 Integration",
   "hacs": "1.6.0",
-  "homeassistant": "2024.1.0b0",
+  "homeassistant": "2024.11.0",
   "render_readme": true
 }


### PR DESCRIPTION
older version are no longer supported. The way configs are handled has changed and this component is no longer working on older installs