### PR TITLE
Update README.md for ABRP fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,25 +96,7 @@ rest_command:
     method: post
     headers:
       Authorization: "APIKEY {{ api_key }}"
-    payload: >
-      {
-          "tlm": {
-              "utc": {{ utc }},
-              "soc": {{ soc }},
-              "soh": {{ soh }},
-              "power": {{ power }},
-              "speed": {{ speed }},
-              "lat": {{ lat }},
-              "lon": {{ lon }},
-              "is_charging": {{ is_charging }},
-              "is_dcfc": {{ is_dcfc }},
-              "is_parked": {{ is_parked }},
-              "elevation": {{ elevation }},
-              "ext_temp": {{ ext_temp }},
-              "odometer": {{ odometer }},
-              "est_battery_range": {{ est_battery_range }}
-          }
-      }
+    payload: {"tlm":{"utc":{{utc}},"soc":{{soc}},"soh":{{soh}},"power":{{power}},"speed":{{speed}},"lat":{{lat}},"lon":{{lon}},"is_charging":{{is_charging}},"is_dcfc":{{is_dcfc}},"is_parked":{{is_parked}},"elevation":{{elevation}},"ext_temp":{{ext_temp}},"odometer":{{odometer}},"est_battery_range":{{est_battery_range}}
 ```
 
 ## Contributions are welcome!

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ rest_command:
     method: post
     headers:
       Authorization: "APIKEY {{ api_key }}"
-    payload: {"tlm":{"utc":{{utc}},"soc":{{soc}},"soh":{{soh}},"power":{{power}},"speed":{{speed}},"lat":{{lat}},"lon":{{lon}},"is_charging":{{is_charging}},"is_dcfc":{{is_dcfc}},"is_parked":{{is_parked}},"elevation":{{elevation}},"ext_temp":{{ext_temp}},"odometer":{{odometer}},"est_battery_range":{{est_battery_range}}
+    payload: {"data":[{"token":"{{ token }}",{"tlm":{"utc":{{utc}},"soc":{{soc}},"soh":{{soh}},"power":{{power}},"speed":{{speed}},"lat":{{lat}},"lon":{{lon}},"is_charging":{{is_charging}},"is_dcfc":{{is_dcfc}},"is_parked":{{is_parked}},"elevation":{{elevation}},"ext_temp":{{ext_temp}},"odometer":{{odometer}},"est_battery_range":{{est_battery_range}}}]}
 ```
 
 ## Contributions are welcome!

--- a/README.md
+++ b/README.md
@@ -92,10 +92,29 @@ And this to your `configuration.yaml` to create the `rest_command`.
 ```yaml
 rest_command:
   abrp:
-    url: https://api.iternio.com/1/tlm/send?token={{ token }}&tlm={"utc":{{ utc }},"soc":"{{ soc }}","soh":"{{ soh }}","power":"{{ power }}","speed":"{{ speed }}","lat":"{{ lat }}","lon":"{{ lon }}","is_charging":"{{ is_charging }}","is_dcfc":"{{ is_dcfc }}","is_parked":"{{ is_parked }}","elevation":"{{ elevation }}","ext_temp":"{{ ext_temp }}","odometer":"{{ odometer }}","est_battery_range":"{{ est_battery_range }}"}
+    url: https://api.iternio.com/1/tlm/send
     method: post
     headers:
       Authorization: "APIKEY {{ api_key }}"
+    payload: >
+      {
+          "tlm": {
+              "utc": {{ utc }},
+              "soc": {{ soc }},
+              "soh": {{ soh }},
+              "power": {{ power }},
+              "speed": {{ speed }},
+              "lat": {{ lat }},
+              "lon": {{ lon }},
+              "is_charging": {{ is_charging }},
+              "is_dcfc": {{ is_dcfc }},
+              "is_parked": {{ is_parked }},
+              "elevation": {{ elevation }},
+              "ext_temp": {{ ext_temp }},
+              "odometer": {{ odometer }},
+              "est_battery_range": {{ est_battery_range }}
+          }
+      }
 ```
 
 ## Contributions are welcome!


### PR DESCRIPTION
ABRP made a change to their API forcing to avoid double quotes for their Timestamp.  

I didn't know how doing it in GET method and it's easier to customise or even just read if it's in POST + Payload in json