### PR TITLE
Disable tank flap sensor by default

### DIFF
--- a/custom_components/smarthashtag/sensor.py
+++ b/custom_components/smarthashtag/sensor.py
@@ -915,6 +915,7 @@ ENTITY_SAFETY_DESCRIPTIONS = (
         translation_key="tank_flap_status",
         name="Tank flap status",
         icon="mdi:gas-station",
+        entity_registry_enabled_default=False,
     ),
 )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - The "Tank flap status" sensor is now disabled by default in the entity registry, consistent with other similar sensors. No changes to existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->