### PR TITLE
fix: lock on/off value

### DIFF
--- a/custom_components/smarthashtag/binary_sensor.py
+++ b/custom_components/smarthashtag/binary_sensor.py
@@ -30,8 +30,7 @@ LOCK_ENTITIES = (
         name="Central locking status",
         icon="mdi:lock",
         device_class=BinarySensorDeviceClass.LOCK,
-        is_on_fn=lambda state, key: state.safety.central_locking_status
-        != 0,  # tested with Smart #1 with locked state
+        is_on_fn=lambda state, key: state.safety.central_locking_status == 0,
     ),
     SmartHashtagBinarySensorEntityDescription(
         key="door_lock_status_driver",
@@ -40,7 +39,7 @@ LOCK_ENTITIES = (
         icon="mdi:lock",
         device_class=BinarySensorDeviceClass.LOCK,
         entity_registry_enabled_default=False,
-        is_on_fn=lambda state, key: state.safety.door_lock_status_driver == 1,
+        is_on_fn=lambda state, key: state.safety.door_lock_status_driver == 0,
     ),
     SmartHashtagBinarySensorEntityDescription(
         key="door_lock_status_driver_rear",
@@ -49,7 +48,7 @@ LOCK_ENTITIES = (
         icon="mdi:lock",
         device_class=BinarySensorDeviceClass.LOCK,
         entity_registry_enabled_default=False,
-        is_on_fn=lambda state, key: state.safety.door_lock_status_driver_rear == 1,
+        is_on_fn=lambda state, key: state.safety.door_lock_status_driver_rear == 0,
     ),
     SmartHashtagBinarySensorEntityDescription(
         key="door_lock_status_passenger",
@@ -58,7 +57,7 @@ LOCK_ENTITIES = (
         icon="mdi:lock",
         device_class=BinarySensorDeviceClass.LOCK,
         entity_registry_enabled_default=False,
-        is_on_fn=lambda state, key: state.safety.door_lock_status_passenger == 1,
+        is_on_fn=lambda state, key: state.safety.door_lock_status_passenger == 0,
     ),
     SmartHashtagBinarySensorEntityDescription(
         key="door_lock_status_passenger_rear",
@@ -67,7 +66,7 @@ LOCK_ENTITIES = (
         icon="mdi:lock",
         device_class=BinarySensorDeviceClass.LOCK,
         entity_registry_enabled_default=False,
-        is_on_fn=lambda state, key: state.safety.door_lock_status_passenger_rear == 1,
+        is_on_fn=lambda state, key: state.safety.door_lock_status_passenger_rear == 0,
     ),
     SmartHashtagBinarySensorEntityDescription(
         key="door_open_status_driver",
@@ -121,7 +120,7 @@ LOCK_ENTITIES = (
         icon="mdi:car-brake-parking",
         device_class=BinarySensorDeviceClass.LOCK,
         entity_registry_enabled_default=False,
-        is_on_fn=lambda state, key: state.safety.electric_park_brake_status == 1,
+        is_on_fn=lambda state, key: state.safety.electric_park_brake_status != 1,
     ),
     SmartHashtagBinarySensorEntityDescription(
         key="trunk_lock_status",
@@ -129,7 +128,7 @@ LOCK_ENTITIES = (
         name="Trunk lock status",
         device_class=BinarySensorDeviceClass.LOCK,
         icon="mdi:lock",
-        is_on_fn=lambda state, key: state.safety.trunk_lock_status == 1,
+        is_on_fn=lambda state, key: state.safety.trunk_lock_status != 1,
     ),
     SmartHashtagBinarySensorEntityDescription(
         key="trunk_open_status",

--- a/tests/test_binary_sensors.py
+++ b/tests/test_binary_sensors.py
@@ -26,11 +26,11 @@ SENSOR_TESTS = {
     #        "expected_value": "off",
     #    },
     #    "binary_sensor.door_open_status_driver": {
-    #        "device_class": "lock",
+    #        "device_class": "door",
     #        "expected_value": "off",
     #    },
     #    "binary_sensor.door_open_status_driver_rear": {
-    #        "device_class": "lock",
+    #        "device_class": "door",
     #        "expected_value": "off",
     #    },
     #    "binary_sensor.door_open_status_passenger": {
@@ -50,7 +50,7 @@ SENSOR_TESTS = {
     #        "expected_value": "off",
     #    },
     #    "binary_sensor.trunk_lock_status": {
-    #        "device_class": "door",
+    #        "device_class": "lock",
     #        "expected_value": "off",
     #    },
     "binary_sensor.smart_trunk_open_status": {

--- a/tests/test_binary_sensors.py
+++ b/tests/test_binary_sensors.py
@@ -7,11 +7,52 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.smarthashtag.const import DOMAIN
 
+# On means open (unlocked), Off means closed (locked)
 SENSOR_TESTS = {
     "binary_sensor.smart_central_locking_status": {
         "device_class": "lock",
-        "expected_value": "on",
+        "expected_value": "off",
     },
+    #    "binary_sensor.door_lock_status_driver": {
+    #        "device_class": "lock",
+    #        "expected_value": "off",
+    #    },
+    #    "binary_sensor.oor_lock_status_driver_rear": {
+    #        "device_class": "lock",
+    #        "expected_value": "off",
+    #    },
+    #    "binary_sensor.door_lock_status_passenger": {
+    #        "device_class": "lock",
+    #        "expected_value": "off",
+    #    },
+    #    "binary_sensor.door_open_status_driver": {
+    #        "device_class": "lock",
+    #        "expected_value": "off",
+    #    },
+    #    "binary_sensor.door_open_status_driver_rear": {
+    #        "device_class": "lock",
+    #        "expected_value": "off",
+    #    },
+    #    "binary_sensor.door_open_status_passenger": {
+    #        "device_class": "door",
+    #        "expected_value": "off",
+    #    },
+    #    "binary_sensor.door_open_status_passenger_rear": {
+    #        "device_class": "door",
+    #        "expected_value": "off",
+    #    },
+    #    "binary_sensor.engine_hood_open_status": {
+    #        "device_class": "door",
+    #        "expected_value": "off",
+    #    },
+    #    "binary_sensor.electric_park_brake_status": {
+    #        "device_class": "door",
+    #        "expected_value": "off",
+    #    },
+    #    "binary_sensor.trunk_lock_status": {
+    #        "device_class": "door",
+    #        "expected_value": "off",
+    #    },
     "binary_sensor.smart_trunk_open_status": {
         "device_class": "door",
         "expected_value": "off",
@@ -50,4 +91,7 @@ async def test_binary_sensors(hass: HomeAssistant, smart_fixture: respx.Router):
             state.attributes["device_class"]
             == SENSOR_TESTS[sensor_name]["device_class"]
         )
-        assert state.state == SENSOR_TESTS[sensor_name]["expected_value"]
+        assert (
+            sensor_name + ":" + state.state
+            == sensor_name + ":" + SENSOR_TESTS[sensor_name]["expected_value"]
+        )


### PR DESCRIPTION
Fixes #282 lock values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the logic for lock-related binary sensors so their "on" and "off" states accurately represent the actual lock and safety statuses.
- **Tests**
  - Updated sensor test expectations and assertions to align with the revised sensor state logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->