### PR TITLE
fix: missing door binary value

### DIFF
--- a/custom_components/smarthashtag/binary_sensor.py
+++ b/custom_components/smarthashtag/binary_sensor.py
@@ -128,7 +128,7 @@ LOCK_ENTITIES = (
         name="Trunk lock status",
         device_class=BinarySensorDeviceClass.LOCK,
         icon="mdi:lock",
-        is_on_fn=lambda state, key: state.safety.trunk_lock_status != 1,
+        is_on_fn=lambda state, key: state.safety.trunk_lock_status == 0,
     ),
     SmartHashtagBinarySensorEntityDescription(
         key="trunk_open_status",


### PR DESCRIPTION
Fixes issue in #282 with trunk lock and break that was missed in #284

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of the trunk lock status indicator for the related binary sensor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->