### PR TITLE
Bugfix: Charger connection status has no unit of measurement

### DIFF
--- a/custom_components/smarthashtag/sensor.py
+++ b/custom_components/smarthashtag/sensor.py
@@ -1104,6 +1104,8 @@ class SmartHashtagBatteryRangeSensor(SmartHashtagEntity, SensorEntity):
         )
         if "charging_status" in self.entity_description.key:
             return None
+        if "charger_connection_status" in self.entity_description.key:
+            return None
         if isinstance(data, ValueWithUnit):
             return data.unit
 


### PR DESCRIPTION
Return None as a unit of measurement for charger connection status. Similar to charging status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of unit display for charger connection status sensors, ensuring units of measurement are not shown where they are not applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->