### PR TITLE
Charger connected state is true true when connected

### DIFF
--- a/custom_components/smarthashtag/binary_sensor.py
+++ b/custom_components/smarthashtag/binary_sensor.py
@@ -138,6 +138,14 @@ LOCK_ENTITIES = (
         icon="mdi:car-back",
         is_on_fn=lambda state, key: state.safety.trunk_open_status == 1,
     ),
+    SmartHashtagBinarySensorEntityDescription(
+        key="is_charger_connected",
+        translation_key="is_charger_connected",
+        name="is charger connected",
+        device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
+        icon="mdi:power-plug-battery",
+        is_on_fn=lambda state, key: state.battery.is_charger_connected,
+    ),
 )
 
 

--- a/custom_components/smarthashtag/sensor.py
+++ b/custom_components/smarthashtag/sensor.py
@@ -87,12 +87,6 @@ ENTITY_BATTERY_DESCRIPTIONS = (
         entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
-        key="is_charger_connected",
-        translation_key="is_charger_connected",
-        name="is charger connected",
-        icon="mdi:power-plug-battery",
-    ),
-    SensorEntityDescription(
         key="charging_voltage",
         translation_key="charging_voltage",
         name="Charging voltage",


### PR DESCRIPTION
Charger connection state is a boolean value. So it is moved to the binary sensors.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new binary sensor that indicates whether the charger is connected, with an updated icon and device class for easier identification.

- **Bug Fixes**
  - Adjusted unit handling for charger connection status sensors to ensure correct display and consistency.

- **Refactor**
  - Removed the previous sensor entry for charger connection status, consolidating functionality under the new binary sensor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->