### PR TITLE
feat: Add INTL region support and reconfigure flow

### DIFF
--- a/custom_components/smarthashtag/__init__.py
+++ b/custom_components/smarthashtag/__init__.py
@@ -10,13 +10,16 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from pysmarthashtag.account import SmartAccount
-from pysmarthashtag.const import EndpointUrls
+from pysmarthashtag.const import EndpointUrls, SmartRegion, get_endpoint_urls_for_region
 
 from .const import (
     CONF_API_BASE_URL,
     CONF_API_BASE_URL_V2,
     CONF_REGION,
+    DEFAULT_REGION,
     REGION_CUSTOM,
+    REGION_EU,
+    REGION_INTL,
 )
 from .coordinator import SmartHashtagDataUpdateCoordinator
 
@@ -57,7 +60,7 @@ async def async_setup_entry(
     """
     # Determine endpoint URLs based on region or custom settings
     endpoint_urls = None
-    region = entry.data.get(CONF_REGION)
+    region = entry.data.get(CONF_REGION, DEFAULT_REGION)
 
     if region == REGION_CUSTOM:
         # Use custom endpoints if provided
@@ -68,8 +71,14 @@ async def async_setup_entry(
                 api_base_url=custom_api_base_url or None,
                 api_base_url_v2=custom_api_base_url_v2 or None,
             )
-    # For EU region (default) or unrecognized region, endpoint_urls remains None
-    # and SmartAccount will use default EU endpoints
+    elif region == REGION_INTL:
+        # Use international endpoints
+        endpoint_urls = get_endpoint_urls_for_region(SmartRegion.INTL)
+    elif region == REGION_EU:
+        # Use EU endpoints (default)
+        endpoint_urls = get_endpoint_urls_for_region(SmartRegion.EU)
+    # If region is None or unrecognized, endpoint_urls remains None
+    # and SmartAccount will use default endpoints
 
     entry.runtime_data = SmartHashtagDataUpdateCoordinator(
         hass=hass,

--- a/custom_components/smarthashtag/const.py
+++ b/custom_components/smarthashtag/const.py
@@ -9,7 +9,7 @@ LOGGER: Logger = getLogger(__package__)
 NAME = "Smart"
 DOMAIN = "smarthashtag"
 DOMAIN_DATA = f"{DOMAIN}_data"
-VERSION = "0.8.0"
+VERSION = "0.8.0-intl"
 
 ATTRIBUTION = "Data provided by http://smart.com/"
 ISSUE_URL = "https://github.com/DasBasti/SmartHashtag/issues"
@@ -51,10 +51,12 @@ DEFAULT_REGION = "eu"
 
 # Region options
 REGION_EU = "eu"
+REGION_INTL = "intl"
 REGION_CUSTOM = "custom"
 
 REGIONS = {
     REGION_EU: "Europe (Hello Smart EU)",
+    REGION_INTL: "International (Hello Smart International - Australia, Singapore, etc.)",
     REGION_CUSTOM: "Custom Endpoints",
 }
 

--- a/custom_components/smarthashtag/manifest.json
+++ b/custom_components/smarthashtag/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/DasBasti/SmartHashtag/issues",
   "requirements": ["pysmarthashtag==0.8.1"],
-  "version": "0.8.0"
+  "version": "0.8.0-intl"
 }

--- a/custom_components/smarthashtag/translations/de.json
+++ b/custom_components/smarthashtag/translations/de.json
@@ -22,13 +22,29 @@
           "api_base_url": "API-Basis-URL",
           "api_base_url_v2": "API-Basis-URL v2"
         }
+      },
+      "reconfigure": {
+        "description": "Aktualisieren Sie Ihre Smart-Kontodaten oder ändern Sie die Region. Die Integration wird nach dem Speichern neu geladen.",
+        "data": {
+          "username": "Benutzername",
+          "password": "Passwort",
+          "region": "Region / Endpunkt"
+        }
+      },
+      "reconfigure_vehicle": {
+        "description": "Fahrzeug-VIN für das aktualisierte Konto auswählen",
+        "data": {
+          "vehicle": "Vehicle Identification Number"
+        }
       }
     },
     "error": {
       "auth": "Authentifizierung fehlgeschlagen, bitte überprüfen Sie Ihre Anmeldeinformationen und versuchen Sie es erneut.",
       "custom_endpoints_required": "Mindestens eine benutzerdefinierte Endpunkt-URL muss angegeben werden"
     },
-    "abort": {}
+    "abort": {
+      "reconfigure_successful": "Konto erfolgreich aktualisiert. Die Integration wird neu geladen."
+    }
   },
   "options": {
     "step": {

--- a/custom_components/smarthashtag/translations/en.json
+++ b/custom_components/smarthashtag/translations/en.json
@@ -22,13 +22,29 @@
           "api_base_url": "API Base URL",
           "api_base_url_v2": "API Base URL v2"
         }
+      },
+      "reconfigure": {
+        "description": "Update your Smart account credentials or change region. The integration will reload after saving.",
+        "data": {
+          "username": "Username",
+          "password": "Password",
+          "region": "Region / Endpoint"
+        }
+      },
+      "reconfigure_vehicle": {
+        "description": "Select vehicle VIN for the updated account",
+        "data": {
+          "vehicle": "Vehicle identification number"
+        }
       }
     },
     "error": {
       "auth": "Auth failed, please check your username and password",
       "custom_endpoints_required": "At least one custom endpoint URL must be provided"
     },
-    "abort": {}
+    "abort": {
+      "reconfigure_successful": "Account updated successfully. The integration will reload."
+    }
   },
   "options": {
     "step": {


### PR DESCRIPTION
Add International (INTL) region support for Hello Smart International users (Australia, Singapore, etc.) alongside the existing EU region. Also adds a reconfigure flow so users can update credentials or switch regions without removing and re-adding the integration.

Changes:

__init__.py:
- Import SmartRegion and get_endpoint_urls_for_region from pysmarthashtag.const
- Resolve endpoint URLs for EU and INTL regions explicitly instead of relying solely on default (None) fallback
- Default region to DEFAULT_REGION when not set in config entry

config_flow.py:
- Import INTL region constants and endpoint resolution helpers
- Add async_step_reconfigure() for credential/region updates via the UI
- Add _finish_reconfigure() to handle vehicle auto-selection or prompt
- Add async_step_reconfigure_vehicle() for multi-vehicle accounts
- Route custom_endpoints step back through reconfigure when applicable
- Resolve EU and INTL endpoints in _test_credentials() for validation

const.py:
- Bump VERSION to 0.8.0-intl
- Add REGION_INTL constant and label to REGIONS dict

manifest.json:
- Bump version to 0.8.0-intl

translations/en.json, translations/de.json:
- Add reconfigure step strings (description, username, password, region)
- Add reconfigure_vehicle step strings
- Add reconfigure_successful abort message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to reconfigure account credentials and region without reinstalling the integration.
  * Added support for international region endpoints and improved regional endpoint handling for EU and international regions.

* **Chores**
  * Version updated to 0.8.0-intl.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->