### PR TITLE
Update README with fixes to rest_command snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ triggers:
   - entity_id:
       - sensor.smart_last_update
     trigger: state
-conditions: []
+conditions:
+  - condition: template
+    value_template: "{{ states('sensor.smart_last_update') not in ['unavailable', 'unknown'] }}"
 actions:
   - action: rest_command.abrp
     data:


### PR DESCRIPTION
This PR addresses issues with the snippets for syncing ABRP with telemetry API.

The major issue was with using payload instead of the recommended query parameters ([API reference](https://documenter.getpostman.com/view/7396339/SWTK5a8w#fdb20525-51da-4195-8138-54deabe907d5)).

Removed speed, which is not available, and did some small changes to how values are mapped.

It now also prevents automation from running when the sensor becomes unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated REST integration examples with clearer payload structure and URL-query usage.
  * Standardized null handling for latitude, longitude and elevation in examples.
  * Added examples for parking status and fast-charger capability fields (is_parked, is_dcfc) with conditional mapping.
  * Clarified headers and payload formatting across configuration samples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->