### PR TITLE
chore: include Smart #5 in project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Smart #1 and #3 Integration
+# Smart #1, #3 and #5 Integration
 
 [![GitHub Release][releases-shield]][releases]
 [![License][license-shield]](LICENSE)
@@ -9,7 +9,7 @@
 
 ### Using HACS (Recommended)
 
-1. Search for and install "Smart #1/#3 Integration" in HACS.
+1. Search for and install "Smart #1/#3/#5 Integration" in HACS.
 1. Restart Home Assistant.
 1. In the Home Assistant UI go to "Configuration" -> "Integrations" click "+" and search for "Smart"
 

--- a/custom_components/smarthashtag/__init__.py
+++ b/custom_components/smarthashtag/__init__.py
@@ -1,4 +1,4 @@
-"""Smart #1/#3 for intergration with Home Assistant.
+"""Smart #1/#3/#5 integration with Home Assistant.
 
 For more details about this integration, please refer to
 https://github.com/DasBasti/SmartHashtag

--- a/custom_components/smarthashtag/sensor.py
+++ b/custom_components/smarthashtag/sensor.py
@@ -1,4 +1,4 @@
-"""Sensor platform for Smar #1/#3 intergration."""
+"""Sensor platform for Smart #1/#3/#5 integration."""
 
 from __future__ import annotations
 

--- a/custom_components/smarthashtag/sensor_groups/__init__.py
+++ b/custom_components/smarthashtag/sensor_groups/__init__.py
@@ -1,4 +1,4 @@
-"""Sensor entity description groups for the Smart #1/#3 integration."""
+"""Sensor entity description groups for the Smart #1/#3/#5 integration."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

Cosmetic description refresh: `README.md`, the integration root docstring, and the sensor-platform docstrings still mention only Smart #1 and #3, but the integration has supported Smart #5 (HY-series VINs) since the upstream pysmarthashtag V2 API host branch landed (`vehicle.py:81-89` routes #5 to `API_BASE_URL_V2`).

This makes the user-facing description match reality so HACS / search results don't under-report the integration's scope.

Three description lines refreshed plus two pre-existing typos fixed in passing on lines being touched anyway:
- `"Smar"` → `"Smart"`
- `"intergration"` → `"integration"`

## Test plan

- [x] No behavioural code changes — description / docstring edit only.