### PR TITLE
chore: remove python 3.13 from action matrix

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ The integration is distributed via [HACS](https://hacs.xyz/) (Home Assistant Com
 
 ## Tech Stack
 
-- **Language**: Python 3.12+
+- **Language**: Python 3.14+
 - **Framework**: Home Assistant custom component
 - **Testing**: pytest with pytest-homeassistant-custom-component
 - **Linting**: ruff, flake8
@@ -44,7 +44,7 @@ SmartHashtag/
 
 ### Prerequisites
 
-- Python 3.12+
+- Python 3.14+
 - Virtual environment (recommended)
 
 ### Setup Commands

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.13", "3.14"]
+        python-version: [ "3.14" ]
     name: Pre-commit
     steps:
       - name: Check out the repository
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.13", "3.14"]
+        python-version: [ "3.14" ]
     runs-on: "ubuntu-latest"
     name: Run tests
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.14" ]
+        python-version: ["3.14"]
     name: Pre-commit
     steps:
       - name: Check out the repository
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.14" ]
+        python-version: ["3.14"]
     runs-on: "ubuntu-latest"
     name: Run tests
     steps:

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,5 @@
-# Assume Python 3.13
-target-version = "py313"
+# Assume Python 3.14
+target-version = "py314"
 
 [lint]
 # F - Enable Pyflakes


### PR DESCRIPTION
HA does not support python 3.13 anymore. So we remove it from the build matrix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to adjust Python version testing matrix for pre-commit checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->