### PR TITLE
Increase vehicle data refresh timeout from 10s to 30s

### DIFF
--- a/custom_components/smarthashtag/coordinator.py
+++ b/custom_components/smarthashtag/coordinator.py
@@ -21,6 +21,10 @@ from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, LOGGER
 # Set high enough to tolerate multiple internal API calls failing within a single refresh
 MAX_TRANSIENT_FAILURES = 10
 
+# Timeout (seconds) for a full vehicle data refresh. A healthy refresh is a
+# chain of sequential Smart/Geely cloud calls that can legitimately take ~20s.
+API_TIMEOUT = 30
+
 
 # https://developers.home-assistant.io/docs/integration_fetching_data#coordinated-single-api-poll-for-data-for-all-entities
 class SmartHashtagDataUpdateCoordinator(DataUpdateCoordinator):
@@ -101,7 +105,7 @@ class SmartHashtagDataUpdateCoordinator(DataUpdateCoordinator):
             UpdateFailed: If a SmartRemoteServiceError is raised during the data retrieval.
         """
         try:
-            async with asyncio.timeout(10):
+            async with asyncio.timeout(API_TIMEOUT):
                 await self.account.get_vehicles()
                 # Reset failure counter on success
                 if self._consecutive_failures > 0:


### PR DESCRIPTION
## Problem

My integration showed the car as `unavailable` almost permanently for the past few weeks. After checking the logs, the main culprit was timeouts.

The data update coordinator wraps `account.get_vehicles()` in `asyncio.timeout(10)`. But a full *successful* refresh actually takes ~21s, because it's a long chain of sequential calls to Smart's cloud:

> vehicle status → OTA info → journal authorisation → trip journal → ...

Debug log from a healthy refresh:

```
DEBUG [custom_components.smarthashtag] Finished fetching smarthashtag data in 21.144 seconds (success: True)
```

With the 10s timeout, this fetch reliably trips `asyncio.timeout` → raises `UpdateFailed` → all entities go `unavailable`, even when the API is perfectly healthy.

## Change

Raise the timeout to 30s via a named `API_TIMEOUT` constant (matching the existing `MAX_TRANSIENT_FAILURES` style), so a normal refresh can complete and entities stay available.

## Possible follow-up

Expose this as a configurable option in the options flow alongside `scan_interval`, since fetch time varies with how many sub-calls the backend performs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vehicle data refresh reliability by allowing more time for updates before timing out.
  * Standardized the refresh timeout to reduce unexpected interruptions during polling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->