### PR TITLE
fix(coordinator): force a clean re-login after repeated API failures

### DIFF
--- a/custom_components/smarthashtag/coordinator.py
+++ b/custom_components/smarthashtag/coordinator.py
@@ -178,6 +178,20 @@ class SmartHashtagDataUpdateCoordinator(DataUpdateCoordinator):
                 self._consecutive_failures,
                 error_msg,
             )
+            # Defense-in-depth: some cloud errors (e.g. 4038 "vehicle not in
+            # use", 8040 "VIN not bound") surface as HTTP errors on the data
+            # endpoints and never trip pysmarthashtag's token-refresh path, so
+            # the account keeps replaying a stale session and only a full
+            # reload recovers it. Once we cross the failure ceiling, proactively
+            # invalidate the session so the next poll performs a clean
+            # re-login. Guarded with hasattr for older pysmarthashtag releases.
+            if hasattr(self.account, "invalidate_session"):
+                LOGGER.warning(
+                    "Invalidating Smart session after %d consecutive failures; "
+                    "next poll will re-login from scratch",
+                    self._consecutive_failures,
+                )
+                self.account.invalidate_session()
             raise UpdateFailed(
                 f"API unavailable after {self._consecutive_failures} attempts: {error_msg}"
             ) from exception


### PR DESCRIPTION
## Summary

edit: changed this PR to draft while I work instead on Token Refresh which hopefully replaces this one.

Companion to the `pysmarthashtag` fix "recover cleanly from a failed API-session
exchange". Adds a coordinator-side safety net so the integration stops getting
stuck with **all sensors `unavailable`** (recoverable only by a manual reload)
after repeated cloud failures.

## Problem

Some cloud errors surface as HTTP errors on the **data** endpoints and never
trip the library's token-refresh path:

- `4038` "Current vehicle is not in use"
- `8040` "No vehicle information bounded with this VIN and UID"

Because these never trigger a re-login, the account keeps replaying a stale
session and the coordinator stays failed — the entities go `unavailable` and
only a full integration reload recovers them.

## Change

In `custom_components/smarthashtag/coordinator.py`, once the coordinator crosses
its consecutive-failure ceiling (before raising `UpdateFailed`), it now calls
`SmartAccount.invalidate_session()` so the **next poll performs a clean
re-login** instead of replaying the dead session. The call is guarded with
`hasattr`, so it's a no-op on older `pysmarthashtag` releases that don't expose
the helper.

## Dependency

Requires `pysmarthashtag` with `SmartAccount.invalidate_session()` (see the
companion library PR DasBasti/pySmartHashtag#213). The `hasattr` guard keeps this change safe to ship ahead
of the library bump; it simply does nothing until the newer library is present.

## Testing

Verified live on Home Assistant OS alongside the patched library: after the
failure ceiling the session is invalidated and the following poll re-logs-in
cleanly, rather than requiring a manual reload.

## Trying this branch on Home Assistant

1. Put this branch's `custom_components/smarthashtag/` into your HA config at
   `/config/custom_components/smarthashtag/`. If the integration was installed
   via HACS, remove the HACS copy first — otherwise it shadows your files and
   the change won't take effect.
2. To actually exercise the new re-login (not just the `hasattr` no-op), also
   install a `pysmarthashtag` build that exposes `invalidate_session()` — see the
   companion library PR DasBasti/pySmartHashtag#213 for the wheel + `file://`
   manifest recipe.
3. Restart Home Assistant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
