### PR TITLE
fix: only poll the vehicle selected at setup; surface unbound-VIN (8040) as reauth

### DIFF
--- a/custom_components/smarthashtag/__init__.py
+++ b/custom_components/smarthashtag/__init__.py
@@ -16,6 +16,7 @@ from .const import (
     CONF_API_BASE_URL,
     CONF_API_BASE_URL_V2,
     CONF_REGION,
+    CONF_VEHICLE,
     REGION_CUSTOM,
 )
 from .coordinator import SmartHashtagDataUpdateCoordinator
@@ -71,12 +72,20 @@ async def async_setup_entry(
     # For EU region (default) or unrecognized region, endpoint_urls remains None
     # and SmartAccount will use default EU endpoints
 
+    # Only track the VIN chosen during setup — never poll or create entities for
+    # other vehicles on the account (e.g. shared cars that appear after switching
+    # cars in the phone app). Falls back to all vehicles for legacy entries with
+    # no stored vehicle.
+    configured_vin = entry.data.get(CONF_VEHICLE)
+    tracked_vins = [configured_vin] if configured_vin else None
+
     entry.runtime_data = SmartHashtagDataUpdateCoordinator(
         hass=hass,
         account=SmartAccount(
             username=entry.data[CONF_USERNAME],
             password=entry.data[CONF_PASSWORD],
             endpoint_urls=endpoint_urls,
+            tracked_vins=tracked_vins,
         ),
         entry=entry,
     )

--- a/custom_components/smarthashtag/const.py
+++ b/custom_components/smarthashtag/const.py
@@ -71,3 +71,10 @@ If you have any issues with this you need to open an issue here:
 
 CONF_VEHICLE: Final = "vehicle"
 CONF_VEHICLES: Final = "vehicles"
+
+# Shown when the cloud reports the VIN is no longer bound to the account (8040).
+# No token refresh or re-login recovers this, so tell the user what does.
+UNBOUND_VIN_AUTH_MESSAGE: Final = (
+    "Vehicle no longer bound to the Smart account. "
+    "Re-add the vehicle in the Smart app, then re-authenticate."
+)

--- a/custom_components/smarthashtag/coordinator.py
+++ b/custom_components/smarthashtag/coordinator.py
@@ -15,6 +15,17 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from pysmarthashtag.account import SmartAccount
 from pysmarthashtag.models import SmartAPIError, SmartAuthError, SmartRemoteServiceError
 
+try:
+    # Typed "VIN no longer bound to this account" (cloud code 8040), added in the
+    # token-lifecycle pysmarthashtag. Fall back to a never-raised placeholder on
+    # older library versions so the except clause stays harmless.
+    from pysmarthashtag.models import SmartVehicleUnboundError
+except ImportError:  # pragma: no cover - depends on installed pysmarthashtag
+
+    class SmartVehicleUnboundError(SmartAPIError):  # noqa: N818
+        """Placeholder for older pysmarthashtag without the typed unbound error."""
+
+
 from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, LOGGER
 
 # Maximum consecutive transient failures before raising UpdateFailed
@@ -69,6 +80,8 @@ class SmartHashtagDataUpdateCoordinator(DataUpdateCoordinator):
         """
         try:
             await self.account.get_vehicles()
+        except SmartVehicleUnboundError as exception:
+            raise ConfigEntryAuthFailed(exception) from exception
         except SmartAuthError as exception:
             raise ConfigEntryAuthFailed(exception) from exception
         except SmartRemoteServiceError as exception:
@@ -116,6 +129,17 @@ class SmartHashtagDataUpdateCoordinator(DataUpdateCoordinator):
                 self._consecutive_failures = 0
                 self._last_error = None
                 return self.account.vehicles
+        except SmartVehicleUnboundError as exception:
+            # Terminal: the VIN is no longer bound to the account (cloud 8040).
+            # Neither token refresh nor re-login recovers this — the user must
+            # re-add the vehicle in the Smart app. Surface it as a reauth prompt
+            # rather than churning transient retries / relogins.
+            LOGGER.error(
+                "Vehicle no longer bound to the Smart account (8040): %s. "
+                "Re-add the vehicle in the Smart app, then re-authenticate.",
+                exception,
+            )
+            raise ConfigEntryAuthFailed(exception) from exception
         except SmartAuthError as exception:
             LOGGER.error(
                 "Authentication failed for Smart API: %s. "

--- a/custom_components/smarthashtag/coordinator.py
+++ b/custom_components/smarthashtag/coordinator.py
@@ -26,7 +26,7 @@ except ImportError:  # pragma: no cover - depends on installed pysmarthashtag
         """Placeholder for older pysmarthashtag without the typed unbound error."""
 
 
-from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, LOGGER
+from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, LOGGER, UNBOUND_VIN_AUTH_MESSAGE
 
 # Maximum consecutive transient failures before raising UpdateFailed
 # Set high enough to tolerate multiple internal API calls failing within a single refresh
@@ -81,7 +81,7 @@ class SmartHashtagDataUpdateCoordinator(DataUpdateCoordinator):
         try:
             await self.account.get_vehicles()
         except SmartVehicleUnboundError as exception:
-            raise ConfigEntryAuthFailed(exception) from exception
+            raise ConfigEntryAuthFailed(UNBOUND_VIN_AUTH_MESSAGE) from exception
         except SmartAuthError as exception:
             raise ConfigEntryAuthFailed(exception) from exception
         except SmartRemoteServiceError as exception:
@@ -134,12 +134,8 @@ class SmartHashtagDataUpdateCoordinator(DataUpdateCoordinator):
             # Neither token refresh nor re-login recovers this — the user must
             # re-add the vehicle in the Smart app. Surface it as a reauth prompt
             # rather than churning transient retries / relogins.
-            LOGGER.error(
-                "Vehicle no longer bound to the Smart account (8040): %s. "
-                "Re-add the vehicle in the Smart app, then re-authenticate.",
-                exception,
-            )
-            raise ConfigEntryAuthFailed(exception) from exception
+            LOGGER.error("%s (8040): %s", UNBOUND_VIN_AUTH_MESSAGE, exception)
+            raise ConfigEntryAuthFailed(UNBOUND_VIN_AUTH_MESSAGE) from exception
         except SmartAuthError as exception:
             LOGGER.error(
                 "Authentication failed for Smart API: %s. "

--- a/custom_components/smarthashtag/manifest.json
+++ b/custom_components/smarthashtag/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/DasBasti/SmartHashtag/issues",
-  "requirements": ["pysmarthashtag==0.10.1"],
+  "requirements": ["pysmarthashtag==0.12.0"],
   "version": "0.8.7"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 colorlog==6.10.1
-pysmarthashtag
+pysmarthashtag==0.12.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-pysmarthashtag
+pysmarthashtag==0.12.0
 pytest-homeassistant-custom-component>=0.13.345
 pytest-cov
 pytest-asyncio


### PR DESCRIPTION
## Summary

Companion to the token-lifecycle `pysmarthashtag` rework (DasBasti/pySmartHashtag#214). Two changes:

1. **Only poll the vehicle selected during setup**. stop fetching every vehicle on the account.
2. **Surface a terminal unbound VIN (`8040`) as a reauth prompt** instead of churning transient retries.

> **Draft.** Being validated live on Home Assistant for **one week** before
> calling it a success. Please don't merge yet.

## Problem 1:  every vehicle on the account was polled

The config flow already asks which vehicle to use and stores it
(`CONF_VEHICLE`), and `sensor.py` builds entities **only** for that VIN. But the
library was asked for **all** vehicles on the account, so every extra vehicle was
fetched on each cycle even though its data was never used.

That is unnecessary work, and it couples the configured car to
the health of unrelated ones: fetching OTA info is a mandatory step of the poll
loop, so a single failing endpoint on **any** vehicle aborted the whole refresh
and dropped **every** sensor of the configured car to `unavailable`. Observed in
practice: a transient `HTTP 500` from the OTA service on another vehicle took the
whole integration down until it recovered.

### Change
`__init__.py` now passes the configured VIN through to the account:

```python
configured_vin = entry.data.get(CONF_VEHICLE)
tracked_vins = [configured_vin] if configured_vin else None
account = SmartAccount(..., tracked_vins=tracked_vins)
```

Only that VIN is fetched, polled and turned into entities; other vehicles on the
account are ignored entirely. Falls back to the previous all-vehicles behaviour
for legacy entries with no stored vehicle. Also removes N-1 vehicles' worth of
requests per cycle.

## Problem 2: `8040` was treated as transient

Cloud code `8040` ("VIN no longer bound to this account/UID") is terminal: the
vehicle is genuinely unbound (removed from the account, shared key given up).
Neither a token refresh nor a re-login recovers it. the user must re-add the
vehicle. Treating it as a generic transient failure just retries forever and
leaves the entities stuck `unavailable`.

### Change
`_async_setup` and `_async_update_data` catch the typed
`SmartVehicleUnboundError` and raise `ConfigEntryAuthFailed` with an actionable
message, rather than counting it as a transient failure. Imported defensively
(`ImportError` fallback) so the integration still loads on older
`pysmarthashtag` releases.

## Dependency

Requires the companion library PR (DasBasti/pySmartHashtag#214):

- `tracked_vins` is a **hard** dependency. the `SmartAccount` keyword only
  exists in that version, so the `requirements` pin in `manifest.json` must be
  bumped to the released version that includes it.
- The `8040` handling is a **soft** dependency (defensive import), and is simply
  inert until the newer library is present.

## Trying this branch on Home Assistant

1. Put this branch's `custom_components/smarthashtag/` into your HA config at
   `/config/custom_components/smarthashtag/`. If the integration was installed
   via HACS, remove the HACS copy first. otherwise it shadows your files.
2. Install a `pysmarthashtag` build from the companion PR
   (DasBasti/pySmartHashtag#214). see it for the wheel + `file://` manifest
   recipe. Required for the VIN filter.
3. Restart Home Assistant. The log should show the untracked vehicles being
   ignored, and only the configured VIN being polled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for selecting which vehicle to track in the integration configuration.
  * The integration now monitors and shows only the selected vehicle.

* **Bug Fixes**
  * Improved handling when the tracked vehicle/VIN is no longer linked to the Smart account.
  * The integration now clearly prompts for re-adding the vehicle and re-authenticating, treating it as a definitive authorization issue rather than a temporary failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->