### PR TITLE
fix: race condition causes error "8040 VIN unbound" and unavailable

### DIFF
--- a/custom_components/smarthashtag/coordinator.py
+++ b/custom_components/smarthashtag/coordinator.py
@@ -10,7 +10,7 @@ import httpx
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from pysmarthashtag.account import SmartAccount
 from pysmarthashtag.models import SmartAPIError, SmartAuthError, SmartRemoteServiceError
@@ -31,6 +31,15 @@ from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, LOGGER, UNBOUND_VIN_AUTH_MESSA
 # Maximum consecutive transient failures before raising UpdateFailed
 # Set high enough to tolerate multiple internal API calls failing within a single refresh
 MAX_TRANSIENT_FAILURES = 10
+
+# Consecutive 8040s before the VIN is considered genuinely unbound.
+# A single 8040 is routinely transient: the cloud answers "no vehicle
+# information bounded with this VIN and UID" for a moment right after a
+# session refresh, before it re-associates the VIN with the new session,
+# and the next poll succeeds. Escalating on the first one turns a blip
+# into a reauth prompt that keeps every entity unavailable until someone
+# reloads the entry by hand.
+UNBOUND_FAILURES_BEFORE_REAUTH = 3
 
 # Timeout (seconds) for a full vehicle data refresh. A healthy refresh is a
 # chain of sequential Smart/Geely cloud calls that can legitimately take ~20s.
@@ -69,6 +78,7 @@ class SmartHashtagDataUpdateCoordinator(DataUpdateCoordinator):
         )
         self._update_intervals = {}
         self._consecutive_failures = 0
+        self._unbound_failures = 0
         self._last_error: str | None = None
 
     async def _async_setup(self) -> None:
@@ -81,7 +91,10 @@ class SmartHashtagDataUpdateCoordinator(DataUpdateCoordinator):
         try:
             await self.account.get_vehicles()
         except SmartVehicleUnboundError as exception:
-            raise ConfigEntryAuthFailed(UNBOUND_VIN_AUTH_MESSAGE) from exception
+            # Setup has no history to tell a transient 8040 from a real one, so
+            # let HA retry with backoff instead of demanding reauth up front.
+            # A genuine unbinding still surfaces from the update path.
+            raise ConfigEntryNotReady(UNBOUND_VIN_AUTH_MESSAGE) from exception
         except SmartAuthError as exception:
             raise ConfigEntryAuthFailed(exception) from exception
         except SmartRemoteServiceError as exception:
@@ -127,13 +140,23 @@ class SmartHashtagDataUpdateCoordinator(DataUpdateCoordinator):
                         self._consecutive_failures,
                     )
                 self._consecutive_failures = 0
+                self._unbound_failures = 0
                 self._last_error = None
                 return self.account.vehicles
         except SmartVehicleUnboundError as exception:
-            # Terminal: the VIN is no longer bound to the account (cloud 8040).
-            # Neither token refresh nor re-login recovers this — the user must
-            # re-add the vehicle in the Smart app. Surface it as a reauth prompt
-            # rather than churning transient retries / relogins.
+            # Only terminal once it repeats: a lone 8040 is usually the cloud
+            # catching up after a session refresh. Below the threshold it goes
+            # through the normal transient path so cached data keeps the
+            # entities alive and the next poll can clear it.
+            self._unbound_failures += 1
+            if self._unbound_failures < UNBOUND_FAILURES_BEFORE_REAUTH:
+                LOGGER.warning(
+                    "Vehicle reported as unbound (8040) %d/%d, treating as transient: %s",
+                    self._unbound_failures,
+                    UNBOUND_FAILURES_BEFORE_REAUTH,
+                    exception,
+                )
+                return self._handle_transient_failure(exception)
             LOGGER.error("%s (8040): %s", UNBOUND_VIN_AUTH_MESSAGE, exception)
             raise ConfigEntryAuthFailed(UNBOUND_VIN_AUTH_MESSAGE) from exception
         except SmartAuthError as exception:
@@ -160,47 +183,7 @@ class SmartHashtagDataUpdateCoordinator(DataUpdateCoordinator):
             OSError,
             ConnectionError,
         ) as exception:
-            self._consecutive_failures += 1
-            error_type = type(exception).__name__
-            error_msg = f"{error_type}: {exception}" if str(exception) else error_type
-
-            # Only log if error changed or first occurrence
-            if self._last_error != error_msg:
-                LOGGER.warning(
-                    "Smart API request failed (attempt %d/%d): %s",
-                    self._consecutive_failures,
-                    MAX_TRANSIENT_FAILURES,
-                    error_msg,
-                )
-                self._last_error = error_msg
-
-            # Return last known data to keep entities available if we have it
-            # and haven't exceeded max failures
-            if (
-                self.data is not None
-                and self._consecutive_failures < MAX_TRANSIENT_FAILURES
-            ):
-                LOGGER.debug("Returning cached data to keep entities available")
-                return self.data
-
-            # If no cached data or too many failures, raise UpdateFailed
-            if self.data is None:
-                LOGGER.info(
-                    "Smart API unavailable and no cached data exists: %s",
-                    error_msg,
-                )
-                raise UpdateFailed(
-                    f"API unavailable with no cached data: {error_msg}"
-                ) from exception
-
-            LOGGER.error(
-                "Smart API unavailable after %d consecutive failures: %s",
-                self._consecutive_failures,
-                error_msg,
-            )
-            raise UpdateFailed(
-                f"API unavailable after {self._consecutive_failures} attempts: {error_msg}"
-            ) from exception
+            return self._handle_transient_failure(exception)
         except Exception as exception:
             error_type = type(exception).__name__
             error_msg = str(exception) or "No error message"
@@ -213,6 +196,54 @@ class SmartHashtagDataUpdateCoordinator(DataUpdateCoordinator):
             raise UpdateFailed(
                 f"Unexpected error ({error_type}): {error_msg}"
             ) from exception
+
+    def _handle_transient_failure(self, exception: Exception):
+        """Serve cached data for a transient failure, or fail once it persists.
+
+        Keeps entities alive across a cloud blip and only raises UpdateFailed
+        when there is nothing cached or the failures stop looking transient.
+        """
+        self._consecutive_failures += 1
+        error_type = type(exception).__name__
+        error_msg = f"{error_type}: {exception}" if str(exception) else error_type
+
+        # Only log if error changed or first occurrence
+        if self._last_error != error_msg:
+            LOGGER.warning(
+                "Smart API request failed (attempt %d/%d): %s",
+                self._consecutive_failures,
+                MAX_TRANSIENT_FAILURES,
+                error_msg,
+            )
+            self._last_error = error_msg
+
+        # Return last known data to keep entities available if we have it
+        # and haven't exceeded max failures
+        if (
+            self.data is not None
+            and self._consecutive_failures < MAX_TRANSIENT_FAILURES
+        ):
+            LOGGER.debug("Returning cached data to keep entities available")
+            return self.data
+
+        # If no cached data or too many failures, raise UpdateFailed
+        if self.data is None:
+            LOGGER.info(
+                "Smart API unavailable and no cached data exists: %s",
+                error_msg,
+            )
+            raise UpdateFailed(
+                f"API unavailable with no cached data: {error_msg}"
+            ) from exception
+
+        LOGGER.error(
+            "Smart API unavailable after %d consecutive failures: %s",
+            self._consecutive_failures,
+            error_msg,
+        )
+        raise UpdateFailed(
+            f"API unavailable after {self._consecutive_failures} attempts: {error_msg}"
+        ) from exception
 
     def set_update_interval(self, key: str, deltatime: timedelta) -> None:
         """Update intervals by key and select the shortest"""

--- a/custom_components/smarthashtag/coordinator.py
+++ b/custom_components/smarthashtag/coordinator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import traceback
 from datetime import timedelta
+from typing import Any
 
 import httpx
 from homeassistant.config_entries import ConfigEntry
@@ -197,7 +198,7 @@ class SmartHashtagDataUpdateCoordinator(DataUpdateCoordinator):
                 f"Unexpected error ({error_type}): {error_msg}"
             ) from exception
 
-    def _handle_transient_failure(self, exception: Exception):
+    def _handle_transient_failure(self, exception: Exception) -> Any:
         """Serve cached data for a transient failure, or fail once it persists.
 
         Keeps entities alive across a cloud blip and only raises UpdateFailed

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -399,3 +399,128 @@ async def test_coordinator_max_transient_failures_threshold(
     state = hass.states.get("sensor.smart_last_update")
     assert state
     assert state.state == "unavailable"
+
+
+@pytest.mark.asyncio()
+async def test_coordinator_single_8040_keeps_entities_available(
+    hass: HomeAssistant, smart_fixture: respx.Router
+):
+    """
+    Test that a lone 8040 is treated as transient.
+
+    The cloud answers "no vehicle information bounded with this VIN and UID"
+    for a moment right after a session refresh. Escalating on the first one
+    raised ConfigEntryAuthFailed and left every entity unavailable until the
+    entry was reloaded by hand, even though the vehicle was still bound.
+    """
+    call_count = 0
+
+    async def simulate_unbound(request: Request, route: respx.Route) -> Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 2:
+            return Response(200, json=load_response(RESPONSE_DIR / "vehicle_info.json"))
+        return Response(
+            200,
+            json={
+                "code": "8040",
+                "message": (
+                    "No vehicle information bounded with this VIN and UID. "
+                    "Please check the data"
+                ),
+            },
+        )
+
+    smart_fixture.get(
+        "https://api.ecloudeu.com/remote-control/vehicle/status/TestVIN0000000001?latest=True&target=basic%2Cmore&userId=112233",
+    ).mock(side_effect=simulate_unbound)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "username": "sample_user",
+            "password": "sample_password",
+            "vehicle": "TestVIN0000000001",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = entry.runtime_data
+
+    # Second call still succeeds, so the cache is populated.
+    await coordinator.async_refresh()
+    assert hass.states.get("sensor.smart_last_update").state != "unavailable"
+
+    # Stop scheduled refreshes so only the explicit one below counts, and
+    # start from a clean slate regardless of how many calls setup made.
+    if coordinator._unsub_refresh:
+        coordinator._unsub_refresh()
+        coordinator._unsub_refresh = None
+    coordinator._unbound_failures = 0
+    coordinator._consecutive_failures = 0
+
+    # A single 8040: cached data must keep the entity alive.
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert coordinator._unbound_failures == 1
+    state = hass.states.get("sensor.smart_last_update")
+    assert state
+    assert state.state == "2024-01-23T16:44:00+00:00"
+    assert state.state != "unavailable"
+
+
+@pytest.mark.asyncio()
+async def test_coordinator_repeated_8040_asks_for_reauth(hass: HomeAssistant):
+    """
+    Test that a persistent 8040 is still treated as a real unbinding.
+
+    Below the threshold the cached data is served; on the threshold the
+    coordinator raises ConfigEntryAuthFailed so the user is told to re-add
+    the vehicle.
+    """
+    from homeassistant.exceptions import ConfigEntryAuthFailed
+    from pysmarthashtag.models import SmartVehicleUnboundError
+
+    from custom_components.smarthashtag.coordinator import (
+        UNBOUND_FAILURES_BEFORE_REAUTH,
+    )
+
+    class UnboundAccount:
+        vehicles = None
+
+        async def get_vehicles(self):
+            raise SmartVehicleUnboundError(
+                "VIN not bound to account (code=8040): No vehicle information "
+                "bounded with this VIN and UID. Please check the data"
+            )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "username": "sample_user",
+            "password": "sample_password",
+            "vehicle": "TestVIN0000000001",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    coordinator = SmartHashtagDataUpdateCoordinator(
+        hass=hass,
+        account=UnboundAccount(),
+        entry=entry,
+    )
+    cached = {"cached": "data"}
+    coordinator.data = cached
+
+    # Every attempt below the threshold serves the cache instead of escalating.
+    for expected in range(1, UNBOUND_FAILURES_BEFORE_REAUTH):
+        assert await coordinator._async_update_data() is cached
+        assert coordinator._unbound_failures == expected
+
+    # Reaching the threshold means the vehicle really is gone.
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coordinator._async_update_data()


### PR DESCRIPTION
`8040` has two meanings and only one is terminal. This tightens the evidence needed before acting on it.

This morning I got again the "unavailable" until it restarted. (dddc0b7) was incomplete, maybe unnecessary.

## The principle this keeps

Typed error handling was added so each cloud code gets the remedy that fits it, instead of collapsing everything into a full re-login, which is what used to wedge the integration into `unavailable` and trip the login gateway's rate limiting.

Nothing recovers `8040`: no token operation, no VIN re-bind. If the vehicle really left the account, polling a doomed endpoint forever helps nobody, so stopping the loop and telling the user is right. This PR keeps that.

## What we have since learned

The cloud also emits `8040`, same message, for a sub-second window after a session refresh, before it re-associates the VIN with the new session. The next poll succeeds.

Escalating on the first occurrence (dddc0b7) turns that into an unmount plus a reauth the config flow does not implement, so the entry stays dead until reloaded by hand. Reloading the entry restored live data instantly, which proves the vehicle was never unbound.

The window is narrow. Layer-1 refreshes were running at one every 6 to 11 seconds and the `8040` landed 127 ms after one of them. Each API call in a poll refreshes independently on a `1402`, so one poll refreshes six to ten times over.

Nothing in the message separates the two cases:

```
8040: No vehicle information bounded with this VIN and UID. Please check the data
```

Only repetition can.

## Change

The rule becomes "stop the loop once the condition proves itself" instead of "stop on sight".

- Update path: cached data for the first occurrences, `ConfigEntryAuthFailed` only once `8040` repeats (`UNBOUND_FAILURES_BEFORE_REAUTH = 3`).
- Setup has no history to judge with, so it raises `ConfigEntryNotReady` and lets HA retry with backoff. A real unbinding still surfaces from the update path.
- The transient branch moves into `_handle_transient_failure`, shared by both callers.

A real unbinding still stops the polling and still gets its message, three cycles later. A blip costs one cycle of cached data. Nothing extra reaches the cloud meanwhile: `SmartVehicleUnboundError` is caught by no remedy clause, so an `8040` triggers no refresh, no re-bind and no re-login, before or after this change.

## Tests

Two in `tests/test_coordinator.py`: a single `8040` keeps the entities available (confirmed it fails without this change), and a repeated one still raises `ConfigEntryAuthFailed`. `57 passed, 1 skipped`, ruff check and format clean.

## Out of scope

Nearly every API call starts with a `1402` and refreshes the session. Whether that is a short-lived token, an effectively single-use one, or something the library could avoid, is not established. Reducing it would shrink the window this race lives in, but it is a performance question with its own risk profile, so it is being measured separately rather than bundled here.

## Status

Running on three live instances since this afternoon: two smart #1 on the v1 API and one smart #5 on apiv2, the account where the outage happened. Happy to let it bake longer before you take it, just say so.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporary vehicle connection errors during setup and updates.
  * Cached data remains available during intermittent connection failures.
  * Repeated connection failures now prompt reauthentication after three attempts.
  * Successful updates reset the connection-failure count.
  * Prevented temporary cloud errors from unnecessarily interrupting access to vehicle data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->