### PR TITLE
Claude/issue 439 library bug niyrnr

### DIFF
--- a/custom_components/smarthashtag/manifest.json
+++ b/custom_components/smarthashtag/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/DasBasti/SmartHashtag/issues",
-  "requirements": ["pysmarthashtag==0.12.0"],
+  "requirements": ["pysmarthashtag==0.13.0"],
   "version": "0.8.8"
 }

--- a/custom_components/smarthashtag/manifest.json
+++ b/custom_components/smarthashtag/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/DasBasti/SmartHashtag/issues",
-  "requirements": ["pysmarthashtag==0.13.0"],
+  "requirements": ["pysmarthashtag==0.12.2"],
   "version": "0.8.8"
 }

--- a/custom_components/smarthashtag/sensor.py
+++ b/custom_components/smarthashtag/sensor.py
@@ -195,6 +195,11 @@ class SmartHashtagBatteryRangeSensor(SmartHashtagEntity, SensorEntity):
                 if data.value == -0.0:
                     return 0.0
 
+            if "charger_connection_status" in self.entity_description.key:
+                # The raw code cannot serve as an enum option, so report the name
+                # the library derives from it.
+                return vehicle.battery.charger_connection_state
+
             if "charging_status" in self.entity_description.key:
                 if isinstance(data, str):
                     data = data.lower()

--- a/custom_components/smarthashtag/sensor_groups/battery.py
+++ b/custom_components/smarthashtag/sensor_groups/battery.py
@@ -7,6 +7,12 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
+from pysmarthashtag.vehicle.battery import CHARGER_CONNECTION_STATES, CHARGING_STATES
+
+# Home Assistant only offers a sensor's states in the automation editor when the
+# entity declares them as a list of strings. Both lists are derived from the
+# library so a new state cannot silently go missing here.
+CHARGING_STATUS_OPTIONS = [state.lower() for state in CHARGING_STATES]
 
 ENTITY_BATTERY_DESCRIPTIONS = (
     SensorEntityDescription(
@@ -40,15 +46,7 @@ ENTITY_BATTERY_DESCRIPTIONS = (
         translation_key="charging_status",
         name="Charging status",
         icon="mdi:power-plug-battery",
-        options={
-            "charging": "charging",
-            "complete": "fully charged",
-            "dc_charging": "DC charging",
-            "default": "default",
-            "not_charging": "not charging",
-            "error": "Error",
-            "unknown": "unknown",
-        },
+        options=CHARGING_STATUS_OPTIONS,
         device_class=SensorDeviceClass.ENUM,
     ),
     SensorEntityDescription(
@@ -63,12 +61,7 @@ ENTITY_BATTERY_DESCRIPTIONS = (
         translation_key="charger_connection_status",
         name="Charger connection status",
         icon="mdi:battery-unknown",
-        options={
-            0: "not connected",
-            1: "tbd",
-            2: "plugged, not charging",
-            3: "charging",
-        },
+        options=list(CHARGER_CONNECTION_STATES),
         device_class=SensorDeviceClass.ENUM,
         entity_registry_enabled_default=False,
     ),

--- a/custom_components/smarthashtag/translations/de.json
+++ b/custom_components/smarthashtag/translations/de.json
@@ -82,7 +82,14 @@
           "charging": "laden",
           "dc_charging": "DC LAden",
           "default": "Standard",
-          "error": "Fehler"
+          "error": "Fehler",
+          "fully_charged": "voll geladen",
+          "finished_fully_charged": "beendet, voll geladen",
+          "finished_not_full": "beendet, nicht voll",
+          "invalid": "ungültig",
+          "plugged_in": "eingesteckt",
+          "waiting_for_charging": "wartet auf Ladung",
+          "target_reached": "Ziel erreicht"
         }
       },
       "charging_status_raw": {
@@ -91,10 +98,10 @@
       "charger_connection_status": {
         "name": "Ladeanschluss",
         "state": {
-          "0": "nicht verbunden",
-          "1": "dc verbunden",
-          "2": "verbunden, nicht ladend",
-          "3": "laden"
+          "not_connected": "nicht verbunden",
+          "dc_connected": "dc verbunden",
+          "plugged_not_charging": "verbunden, nicht ladend",
+          "charging": "laden"
         }
       },
       "is_charger_connected": {

--- a/custom_components/smarthashtag/translations/en.json
+++ b/custom_components/smarthashtag/translations/en.json
@@ -82,7 +82,14 @@
           "charging": "charging",
           "dc_charging": "DC charging",
           "default": "Default",
-          "error": "Error"
+          "error": "Error",
+          "fully_charged": "fully charged",
+          "finished_fully_charged": "finished, fully charged",
+          "finished_not_full": "finished, not full",
+          "invalid": "invalid",
+          "plugged_in": "plugged in",
+          "waiting_for_charging": "waiting for charging",
+          "target_reached": "target reached"
         }
       },
       "charging_status_raw": {
@@ -91,10 +98,10 @@
       "charger_connection_status": {
         "name": "Charger connection",
         "state": {
-          "0": "not connected",
-          "1": "dc connected",
-          "2": "plugged, not charging",
-          "3": "charging"
+          "not_connected": "not connected",
+          "dc_connected": "dc connected",
+          "plugged_not_charging": "plugged, not charging",
+          "charging": "charging"
         }
       },
       "is_charger_connected": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 colorlog==6.12.0
-pysmarthashtag==0.12.0
+pysmarthashtag==0.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 colorlog==6.12.0
-pysmarthashtag==0.13.0
+pysmarthashtag==0.12.2

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-pysmarthashtag==0.13.0
+pysmarthashtag==0.12.2
 pytest-homeassistant-custom-component>=0.13.348
 pytest-cov
 pytest-asyncio

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-pysmarthashtag==0.12.0
+pysmarthashtag==0.13.0
 pytest-homeassistant-custom-component>=0.13.348
 pytest-cov
 pytest-asyncio

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -4,13 +4,18 @@ import logging
 
 import pytest
 import respx
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.core import HomeAssistant
 from httpx import Request, Response
 from pysmarthashtag.tests import RESPONSE_DIR, load_response
+from pysmarthashtag.vehicle.battery import CHARGER_CONNECTION_STATES, CHARGING_STATES
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.smarthashtag.const import DOMAIN
 from custom_components.smarthashtag.sensor import remove_vin_from_key, vin_from_key
+from custom_components.smarthashtag.sensor_groups.battery import (
+    ENTITY_BATTERY_DESCRIPTIONS,
+)
 
 
 def test_remove_vin_from_key():
@@ -743,3 +748,78 @@ async def test_native_unit_of_measurement_with_none_vehicle(
     state = hass.states.get("sensor.smart_last_update")
     assert state is not None
     assert state.state == "2024-01-23T16:44:00+00:00"
+
+
+def test_enum_descriptions_declare_their_options_as_a_list():
+    """Test that every enum sensor declares its states as a list of strings.
+
+    Home Assistant only offers a sensor's states as automation trigger values when
+    the entity exposes them in the "options" attribute as a JSON list. A mapping
+    left the From/To pickers of the automation editor empty, see issue #439.
+    """
+    enum_descriptions = [
+        description
+        for description in ENTITY_BATTERY_DESCRIPTIONS
+        if description.device_class == SensorDeviceClass.ENUM
+    ]
+    assert enum_descriptions
+
+    for description in enum_descriptions:
+        assert isinstance(description.options, list), description.key
+        assert all(isinstance(option, str) for option in description.options), (
+            description.key
+        )
+
+
+def test_charging_status_offers_every_library_state():
+    """Test that no state the library can report is missing from the options.
+
+    States that were not listed got reported as unknown, so they could neither be
+    seen nor selected.
+    """
+    description = next(
+        description
+        for description in ENTITY_BATTERY_DESCRIPTIONS
+        if description.key == "charging_status"
+    )
+
+    assert set(description.options) == {state.lower() for state in CHARGING_STATES}
+
+
+def test_charger_connection_offers_every_library_state():
+    """Test that the charger connection lists the names the library reports."""
+    description = next(
+        description
+        for description in ENTITY_BATTERY_DESCRIPTIONS
+        if description.key == "charger_connection_status"
+    )
+
+    assert set(description.options) == set(CHARGER_CONNECTION_STATES)
+
+
+@pytest.mark.asyncio()
+async def test_charging_status_state_is_selectable(
+    hass: HomeAssistant, smart_fixture: respx.Router
+):
+    """Test that the charging status publishes a state contained in its options."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "username": "sample_user",
+            "password": "sample_password",
+            "vehicle": "TestVIN0000000001",
+        },
+    )
+
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.smart_charging_status")
+    assert state
+    assert state.attributes["device_class"] == "enum"
+
+    options = state.attributes["options"]
+    assert isinstance(options, list)
+    assert state.state in options


### PR DESCRIPTION
fix(sensor): let enum sensors offer their states as trigger values
The automation editor fills the From/To pickers of a state trigger from the
"options" attribute, but only when that attribute is a JSON list. Both enum
sensors declared their options as a mapping of value to label, so the pickers
stayed empty and the sensors could not be used in a trigger at all.

Declare the options as lists built from the state sets pySmartHashtag now
exports. The charging status thereby gains the states that used to be dropped
and reported as unknown, and the charger connection reports the name the
library derives from the raw code, since an integer can never match an option.

The connection states move from the raw codes to those names in both
translations. Requires pysmarthashtag 0.13.0.

Fixes https://github.com/DasBasti/SmartHashtag/issues/439

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Battery and charger connection sensors now display descriptive connection states instead of raw numeric values.
  * Charging and charger connection options now stay aligned with supported device states.
* **Improvements**
  * Added expanded English and German translations for charging and connection states.
  * Charging status options are now presented consistently as selectable text values.
* **Tests**
  * Added coverage to verify supported charging states, connection states, and selectable sensor options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->